### PR TITLE
fix: handle empty cors origins

### DIFF
--- a/backend-graphql/src/index.ts
+++ b/backend-graphql/src/index.ts
@@ -24,11 +24,15 @@ const FALLBACK_PUBLIC = getLanIP()
 const PUBLIC_HOST = process.env.PUBLIC_HOST || FALLBACK_PUBLIC
 
 /** Permitir orígenes declarados por ENV o localhost/LAN por defecto */
+const corsOriginsEnv =
+  process.env.CORS_ORIGINS?.split(",").map((s) => s.trim()).filter(Boolean)
 const corsOrigins =
-  process.env.CORS_ORIGINS?.split(",").map((s) => s.trim()).filter(Boolean) ?? [
-    `http://localhost:5173`,
-    `http://${PUBLIC_HOST}:5173`,
-  ]
+  corsOriginsEnv && corsOriginsEnv.length > 0
+    ? corsOriginsEnv
+    : [
+        `http://localhost:5173`,
+        `http://${PUBLIC_HOST}:5173`,
+      ]
 
 /** Instancia Yoga (GraphQL) */
 const yoga = createYoga<Context>({


### PR DESCRIPTION
## Summary
- handle empty CORS_ORIGINS env var by falling back to defaults

## Testing
- `pnpm run test` (fails: Missing script: test)
- `pnpm exec tsc -p backend-graphql/tsconfig.json --noEmit` (fails: Namespace 'Prisma' has no exported member 'clientsWhereInput' and more)


------
https://chatgpt.com/codex/tasks/task_e_68addf07534c832a9b553a9260b10a7a