### PR TITLE
chore: guard Apollo token log in dev

### DIFF
--- a/control/src/apollo/client.ts
+++ b/control/src/apollo/client.ts
@@ -11,8 +11,10 @@ const httpLink = new HttpLink({
 
 const authLink = setContext((_, { headers }) => {
   const token = getToken()
-  // 👇 LOG para verificar qué token se está leyendo
-  console.log("[Apollo authLink] token:", token)
+  // Solo mostrar el token en modo desarrollo para evitar exponerlo en producción
+  if (import.meta.env.DEV) {
+    console.log("[Apollo authLink] token:", token)
+  }
 
   return {
     headers: {


### PR DESCRIPTION
## Summary
- only log token in Apollo auth link during development to avoid leaking in production

## Testing
- `pnpm --filter control build` (fails: This expression is not callable.)

------
https://chatgpt.com/codex/tasks/task_e_68ade7988b7c832a97b1a5227e0b8ac4