### PR TITLE
refactor: centralize logging and protect user data

### DIFF
--- a/backend-graphql/src/context.ts
+++ b/backend-graphql/src/context.ts
@@ -3,6 +3,7 @@
 import type { PrismaClient } from "@prisma/client"
 import { db } from "../db"
 import jwt from "jsonwebtoken"
+import { logger } from "./logger"
 
 export type Role = "admin" | "frontdesk" | "mechanic"
 const VALID_ROLES = new Set<Role>(["admin", "frontdesk", "mechanic"])
@@ -52,9 +53,10 @@ export function createContext({ request }: { request: Request }): Context {
     }
   }
 
-  // 👇 LOG: aquí vemos qué llega realmente
-  console.log("[Context] Authorization header:", authHeader)
-  console.log("[Context] user:", user)
+  if (process.env.NODE_ENV !== "production") {
+    logger.debug("[Context] Authorization header:", authHeader)
+    logger.debug("[Context] user:", user)
+  }
 
   return { db, user }
 }

--- a/backend-graphql/src/index.ts
+++ b/backend-graphql/src/index.ts
@@ -6,6 +6,7 @@ import { createYoga } from "graphql-yoga"
 import { schema } from "./schema"
 import { createContext, type Context } from "./context"
 import os from "node:os"
+import { logger } from "./logger"
 
 /** Obtiene la IP de la red local (útil para testear en móviles de la misma LAN) */
 function getLanIP() {
@@ -67,12 +68,12 @@ const server = createServer((req, res) => {
 })
 
 server.on("error", (err) => {
-  console.error("❌ HTTP server error:", err)
+  logger.error("❌ HTTP server error:", err)
 })
 
 server.listen(PORT, HOST, () => {
-  console.log("🚀 GraphQL server ready at:")
-  console.log(`   Local:   http://127.0.0.1:${PORT}/graphql`)
-  console.log(`   LAN:     http://${PUBLIC_HOST}:${PORT}/graphql`)
-  console.log(`   Health:  http://127.0.0.1:${PORT}/healthz  |  /readyz`)
+  logger.info("🚀 GraphQL server ready at:")
+  logger.info(`   Local:   http://127.0.0.1:${PORT}/graphql`)
+  logger.info(`   LAN:     http://${PUBLIC_HOST}:${PORT}/graphql`)
+  logger.info(`   Health:  http://127.0.0.1:${PORT}/healthz  |  /readyz`)
 })

--- a/backend-graphql/src/logger.ts
+++ b/backend-graphql/src/logger.ts
@@ -1,0 +1,32 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'
+
+const levels: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  silent: 50,
+}
+
+const DEFAULT_LEVEL: LogLevel = process.env.NODE_ENV === 'production' ? 'info' : 'debug'
+const levelName = (process.env.LOG_LEVEL as LogLevel) || DEFAULT_LEVEL
+const currentLevel = levels[levelName] ?? levels.info
+
+function shouldLog(level: LogLevel) {
+  return levels[level] >= currentLevel
+}
+
+export const logger = {
+  debug: (...args: any[]) => {
+    if (shouldLog('debug')) console.debug(...args)
+  },
+  info: (...args: any[]) => {
+    if (shouldLog('info')) console.info(...args)
+  },
+  warn: (...args: any[]) => {
+    if (shouldLog('warn')) console.warn(...args)
+  },
+  error: (...args: any[]) => {
+    if (shouldLog('error')) console.error(...args)
+  },
+}


### PR DESCRIPTION
## Summary
- add simple configurable logger for backend
- guard header and user logs behind NODE_ENV
- replace scattered console.log calls with logger usage

## Testing
- `pnpm --filter backend-graphql exec tsc -p tsconfig.json --noEmit` *(fails: Prisma types missing in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ade9c5e9fc832ab60c1a8bcec041d0