### PR TITLE
refactor: use unknown for errors

### DIFF
--- a/backend-graphql/src/resolvers/clients.ts
+++ b/backend-graphql/src/resolvers/clients.ts
@@ -2,6 +2,7 @@
 
 import { Context } from "../context";
 import { Prisma } from "@prisma/client";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 
 const toNull = (v?: string | null) => (v && v.trim() ? v.trim() : null);
 const up = (v?: string | null) => (v && v.trim() ? v.trim().toUpperCase() : null);
@@ -105,18 +106,20 @@ export const clientsResolvers = {
           },
         });
         return created;
-      } catch (e: any) {
-        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
-          const target = (e.meta?.target as string[])?.[0] ?? "field";
-          throw new Error(
-            target === "email"
-              ? "Email already exists"
-              : target === "dni"
-              ? "DNI already exists"
-              : target === "vat_number"
-              ? "VAT number already exists"
-              : "Unique constraint failed"
-          );
+      } catch (e: unknown) {
+        if (e instanceof PrismaClientKnownRequestError) {
+          if (e.code === "P2002") {
+            const target = (e.meta?.target as string[])?.[0] ?? "field";
+            throw new Error(
+              target === "email"
+                ? "Email already exists"
+                : target === "dni"
+                ? "DNI already exists"
+                : target === "vat_number"
+                ? "VAT number already exists"
+                : "Unique constraint failed"
+            );
+          }
         }
         throw e;
       }
@@ -187,18 +190,20 @@ export const clientsResolvers = {
 
       try {
         return await db.clients.update({ where: { client_id }, data: payload });
-      } catch (e: any) {
-        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
-          const target = (e.meta?.target as string[])?.[0] ?? "field";
-          throw new Error(
-            target === "email"
-              ? "Email already exists"
-              : target === "dni"
-              ? "DNI already exists"
-              : target === "vat_number"
-              ? "VAT number already exists"
-              : "Unique constraint failed"
-          );
+      } catch (e: unknown) {
+        if (e instanceof PrismaClientKnownRequestError) {
+          if (e.code === "P2002") {
+            const target = (e.meta?.target as string[])?.[0] ?? "field";
+            throw new Error(
+              target === "email"
+                ? "Email already exists"
+                : target === "dni"
+                ? "DNI already exists"
+                : target === "vat_number"
+                ? "VAT number already exists"
+                : "Unique constraint failed"
+            );
+          }
         }
         throw e;
       }
@@ -208,10 +213,14 @@ export const clientsResolvers = {
       try {
         await db.clients.delete({ where: { client_id: clientId } });
         return true;
-      } catch (e: any) {
-        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2003") {
-          // FK constraint (tiene vehículos/órdenes)
-          throw new Error("Cannot delete client with related records (vehicles/work orders).");
+      } catch (e: unknown) {
+        if (e instanceof PrismaClientKnownRequestError) {
+          if (e.code === "P2003") {
+            // FK constraint (tiene vehículos/órdenes)
+            throw new Error(
+              "Cannot delete client with related records (vehicles/work orders)."
+            );
+          }
         }
         throw e;
       }

--- a/backend-graphql/src/resolvers/vehicles.ts
+++ b/backend-graphql/src/resolvers/vehicles.ts
@@ -1,6 +1,7 @@
 // backend-graphql/src/resolvers/vehicles.ts
 
 import type { Context } from "../context"
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library"
 
 /* =========================
    Validation utilities
@@ -153,12 +154,15 @@ export const vehicleResolvers = {
             last_service_date: toDateOrUndefined(args.last_service_date),
           },
         })
-      } catch (err: any) {
-        if (err?.code === "P2002") {
-          const target = (err.meta?.target as string[])?.join(", ") || "unique field"
-          if (target.includes("vin")) throw new Error("VIN already exists.")
-          if (target.includes("license_plate")) throw new Error("License plate already exists.")
-          throw new Error(`Uniqueness conflict on ${target}.`)
+      } catch (err: unknown) {
+        if (err instanceof PrismaClientKnownRequestError) {
+          if (err.code === "P2002") {
+            const target = (err.meta?.target as string[])?.join(", ") || "unique field"
+            if (target.includes("vin")) throw new Error("VIN already exists.")
+            if (target.includes("license_plate"))
+              throw new Error("License plate already exists.")
+            throw new Error(`Uniqueness conflict on ${target}.`)
+          }
         }
         throw err
       }
@@ -276,12 +280,15 @@ export const vehicleResolvers = {
           include: { client: true },
         })
         return updated
-      } catch (err: any) {
-        if (err?.code === "P2002") {
-          const target = (err.meta?.target as string[])?.join(", ") || "unique field"
-          if (target.includes("vin")) throw new Error("VIN already exists.")
-          if (target.includes("license_plate")) throw new Error("License plate already exists.")
-          throw new Error(`Uniqueness conflict on ${target}.`)
+      } catch (err: unknown) {
+        if (err instanceof PrismaClientKnownRequestError) {
+          if (err.code === "P2002") {
+            const target = (err.meta?.target as string[])?.join(", ") || "unique field"
+            if (target.includes("vin")) throw new Error("VIN already exists.")
+            if (target.includes("license_plate"))
+              throw new Error("License plate already exists.")
+            throw new Error(`Uniqueness conflict on ${target}.`)
+          }
         }
         throw err
       }

--- a/control/src/components/common/Delete.tsx
+++ b/control/src/components/common/Delete.tsx
@@ -35,8 +35,11 @@ export default function Delete({
       setLoading(true)
       await onDelete()
       setToast({ type: "success", msg: successMessage })
-    } catch (e: any) {
-      setToast({ type: "error", msg: e?.message || errorMessage })
+    } catch (e: unknown) {
+      setToast({
+        type: "error",
+        msg: e instanceof Error ? e.message : errorMessage,
+      })
     } finally {
       setLoading(false)
       setOpen(false)


### PR DESCRIPTION
## Summary
- replace catch error arguments typed as `any` with `unknown`
- narrow Prisma errors using `PrismaClientKnownRequestError`
- ensure Delete component reports unknown errors safely

## Testing
- `pnpm exec tsc -p backend-graphql/tsconfig.json --noEmit` *(fails: Namespace 'Prisma' has no exported member 'clientsWhereInput')*
- `pnpm exec tsc -p control/tsconfig.json --noEmit` *(fails: DocumentNode has no call signatures)*

------
https://chatgpt.com/codex/tasks/task_e_68aded091440832a8cd417a13513e84d