### PR TITLE
feat: centralize JWT secret configuration

### DIFF
--- a/backend-graphql/src/config.ts
+++ b/backend-graphql/src/config.ts
@@ -1,0 +1,10 @@
+// backend-graphql/src/config.ts
+
+import "dotenv/config"
+
+const jwtSecret = process.env.JWT_SECRET
+if (!jwtSecret) {
+  throw new Error("JWT_SECRET environment variable is not defined")
+}
+
+export const JWT_SECRET = jwtSecret

--- a/backend-graphql/src/context.ts
+++ b/backend-graphql/src/context.ts
@@ -3,6 +3,7 @@
 import type { PrismaClient } from "@prisma/client"
 import { db } from "../db"
 import jwt from "jsonwebtoken"
+import { JWT_SECRET } from "./config"
 import { logger } from "./logger"
 
 export type Role = "admin" | "frontdesk" | "mechanic"
@@ -30,7 +31,7 @@ export function createContext({ request }: { request: Request }): Context {
   if (authHeader?.startsWith("Bearer ")) {
     const token = authHeader.slice(7).trim()
     try {
-      const decoded = jwt.verify(token, process.env.JWT_SECRET!) as any
+      const decoded = jwt.verify(token, JWT_SECRET) as any
 
       if (
         decoded &&

--- a/backend-graphql/src/resolvers/users.ts
+++ b/backend-graphql/src/resolvers/users.ts
@@ -4,13 +4,14 @@ import { Context } from "../context"
 import bcrypt from "bcryptjs"
 import jwt from "jsonwebtoken"
 import { GraphQLError } from "graphql"
+import { JWT_SECRET } from "../config"
 
 function signToken(user: { user_id: number; email: string; role: string }) {
-  const secret = process.env.JWT_SECRET
-  if (!secret) throw new Error("JWT_SECRET is not set")
   // 👇 defensivo: role en minúsculas (el context igual lo normaliza)
   const role = String(user.role).toLowerCase()
-  return jwt.sign({ sub: user.user_id, email: user.email, role }, secret, { expiresIn: "7d" })
+  return jwt.sign({ sub: user.user_id, email: user.email, role }, JWT_SECRET, {
+    expiresIn: "7d",
+  })
 }
 
 // Helper para serializar fechas a ISO de forma segura


### PR DESCRIPTION
## Summary
- add config module that validates JWT_SECRET on startup
- use secure JWT secret in context and user token signing

## Testing
- `pnpm exec tsc -p backend-graphql/tsconfig.json --noEmit` *(fails: Namespace 'Prisma' has no exported member...)*

------
https://chatgpt.com/codex/tasks/task_e_68adecf01604832a8460775d4bfeb1ac