### PR TITLE
fix build scripts and workspace setup

### DIFF
--- a/backend-graphql/package.json
+++ b/backend-graphql/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/index.ts",
+    "build": "tsc",
     "pull": "prisma db pull",
     "generate": "prisma generate"
   }

--- a/backend-graphql/src/resolvers/work_orders.ts
+++ b/backend-graphql/src/resolvers/work_orders.ts
@@ -81,9 +81,9 @@ const buildWhere = (f?: Filter): Prisma.work_ordersWhereInput | undefined => {
     const s = text
     OR.push({ title: { contains: s, mode: "insensitive" } })
     OR.push({ description: { contains: s, mode: "insensitive" } })
-    OR.push({ vehicles: { license_plate: { contains: s, mode: "insensitive" } } })
+    OR.push({ vehicle: { license_plate: { contains: s, mode: "insensitive" } } })
     OR.push({
-      clients: {
+      client: {
         OR: [
           { first_name:   { contains: s, mode: "insensitive" } },
           { last_name:    { contains: s, mode: "insensitive" } },

--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "concurrently -n backend,control,web -c green,cyan,magenta \"pnpm --filter backend-graphql dev\" \"pnpm --filter control dev\" \"pnpm --filter web dev\"",
+    "dev": "concurrently -n backend,control -c green,cyan \"pnpm --filter backend-graphql dev\" \"pnpm --filter control dev\"",
     "dev:backend": "pnpm --filter backend-graphql dev",
     "dev:control": "pnpm --filter control dev",
-    "dev:web": "pnpm --filter web dev",
-    "build": "pnpm --filter backend-graphql build && pnpm --filter control build && pnpm --filter web build"
+    "build": "pnpm --filter backend-graphql build && pnpm --filter control build"
   },
   "dependencies": {
     "@apollo/client": "^3.13.9",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,6 @@
 packages:
   - 'backend-graphql'
   - 'control'
-  - 'web'
 
 onlyBuiltDependencies:
   - '@prisma/client'


### PR DESCRIPTION
## Summary
- add tsc build step for backend-graphql
- clean up work order search filters to match Prisma relations
- remove unused web package from scripts and workspace

## Testing
- `pnpm --filter backend-graphql generate`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68adfece4450832a94a7c1a151be5525