### PR TITLE
build: generate Prisma client before compiling

### DIFF
--- a/backend-graphql/package.json
+++ b/backend-graphql/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "tsc",
+    "build": "prisma generate && tsc",
     "pull": "prisma db pull",
     "generate": "prisma generate"
   }

--- a/backend-graphql/src/resolvers/clients.ts
+++ b/backend-graphql/src/resolvers/clients.ts
@@ -1,7 +1,7 @@
 // backend-graphql/src/resolvers/clients.ts
 
 import { Context } from "../context";
-import { Prisma } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { GraphQLError } from "graphql";
 


### PR DESCRIPTION
## Summary
- run `prisma generate` as part of the build step to ensure type-safe Prisma client
- mark Prisma import in `clients` resolver as type-only

## Testing
- `pnpm --filter backend-graphql build`


------
https://chatgpt.com/codex/tasks/task_e_68ae063d5114832a8c09d6254e198771